### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 .idea/
+.git-credentials

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,5 +1,7 @@
 import uuid
-from jose import jwt
+
+from fastapi import HTTPException
+from jose import jwt, JWTError
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import os
@@ -12,25 +14,20 @@ ALGORITHM = os.getenv("ALGORITHM")
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES"))
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
-    print("Creating access token")
     """Return a signed JWT that contains a unique `jti`."""
     to_encode = data.copy()
 
-    # ---- expiry ---------------------------------------------------------
     expire = datetime.utcnow() + (
         expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode["exp"] = expire
-
-    # ---- jti -------------------------------------------------------------
-    # This is the piece missing from your earlier version.
     to_encode["jti"] = str(uuid.uuid4())
 
     return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
 
-
-
-
 def get_jti_from_token(token: str) -> str:
-    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-    return payload["jti"]
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload["jti"]
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,0 +1,36 @@
+import uuid
+from jose import jwt
+from datetime import datetime, timedelta
+from dotenv import load_dotenv
+import os
+
+# Load environment variables
+load_dotenv()
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+ALGORITHM = os.getenv("ALGORITHM")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES"))
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:
+    print("Creating access token")
+    """Return a signed JWT that contains a unique `jti`."""
+    to_encode = data.copy()
+
+    # ---- expiry ---------------------------------------------------------
+    expire = datetime.utcnow() + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode["exp"] = expire
+
+    # ---- jti -------------------------------------------------------------
+    # This is the piece missing from your earlier version.
+    to_encode["jti"] = str(uuid.uuid4())
+
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+
+
+def get_jti_from_token(token: str) -> str:
+    payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    return payload["jti"]

--- a/docs/jti-session/assignment.md
+++ b/docs/jti-session/assignment.md
@@ -1,0 +1,13 @@
+# Per‑Session Conversation History via jti
+
+## Overview & Goal
+
+Add session‑specific conversation history to the chatbot so that each login gets its own chat context.
+The implementation must:
+
+1. Generate a unique JWT (jti claim) for every login.
+2. Use the jti as the key in the session store.
+3. Persist the chat history only while the token is valid (TTL = ACCESS_TOKEN_EXPIRE_MINUTES).
+4. Maintain the existing streaming API – the front‑end should not change.
+5. Add unit & integration tests for the new behavior.
+6. Document the changes in the repo README and comment code where relevant.

--- a/llm_stream.py
+++ b/llm_stream.py
@@ -1,0 +1,26 @@
+import httpx
+from typing import AsyncGenerator
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+MODEL_NAME = os.getenv("MODEL_NAME")
+OLLAMA_URL = os.getenv("OLLAMA_URL")
+
+async def ollama_stream(history: list[dict]) -> AsyncGenerator[bytes, None]:
+    """
+    Async generator that yields raw bytes from Ollama as soon as they arrive.
+    """
+    payload = {
+        "model": MODEL_NAME,
+        "messages": history,
+        "stream": True,
+    }
+
+    async with httpx.AsyncClient() as client:
+        async with client.stream("POST", OLLAMA_URL, json=payload) as resp:
+            resp.raise_for_status()
+            async for chunk in resp.aiter_bytes():
+                if chunk:
+                    yield chunk

--- a/main.py
+++ b/main.py
@@ -3,21 +3,22 @@ from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel
 import httpx
 from passlib.context import CryptContext
-from datetime import datetime, timedelta
 from jose import JWTError, jwt
-from typing import Annotated
+from typing import Annotated, AsyncGenerator
 from dotenv import load_dotenv
 import os
 from starlette.responses import FileResponse, StreamingResponse
+from auth_utils import get_jti_from_token, create_access_token
+from session_store import sessions
+import time
 
-# Load environment variables
 load_dotenv()
 
 OLLAMA_URL = os.getenv("OLLAMA_URL")
 MODEL_NAME = os.getenv("MODEL_NAME")
 SECRET_KEY = os.getenv("SECRET_KEY")
 ALGORITHM = os.getenv("ALGORITHM")
-ACCESS_TOKEN_EXPIRE_MINUTES = os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES")
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES"))
 USERNAME = os.getenv("USERNAME")
 PASSWORD = os.getenv("PASSWORD")
 
@@ -55,12 +56,6 @@ def authenticate_user(username: str, password: str):
         return None
     return user
 
-def create_access_token(data: dict, expires_delta: timedelta = None):
-    to_encode = data.copy()
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
-    to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-
 async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
@@ -70,17 +65,22 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-def ollama_stream(prompt: str):
+async def ollama_stream(history: list[dict]) -> AsyncGenerator[bytes, None]:
+    """
+    Async generator that yields raw bytes from Ollama as soon as they arrive.
+    """
     payload = {
         "model": MODEL_NAME,
-        "prompt": prompt,
-        "stream": True
+        "messages": history,
+        "stream": True,
     }
 
-    with httpx.stream("POST", OLLAMA_URL, json=payload) as response:
-        for chunk in response.iter_bytes():
-            if chunk:
-                yield chunk
+    async with httpx.AsyncClient() as client:
+        async with client.stream("POST", OLLAMA_URL, json=payload) as resp:
+            resp.raise_for_status()          # raises 4xx/5xx if the request failed
+            async for chunk in resp.aiter_bytes():
+                if chunk:
+                    yield chunk
 
 app = FastAPI()
 @app.get("/")
@@ -91,23 +91,36 @@ def serve_frontend():
 def login(request: LoginRequest) -> TokenResponse:
     user = authenticate_user(request.username, request.password)
     if not user:
-        raise HTTPException(status_code=401, detail="Invalid username or password")
-    token = create_access_token(data={"sub": user["username"]})
+        raise HTTPException(status_code = 401, detail = "Invalid username or password")
+    token = create_access_token(data = {"sub": user["username"]})
     return TokenResponse(accessToken = token)
 
 @app.post("/ask")
 async def ask(
-        request: Request,
-        token: str = Depends(oauth2_scheme)
+    payload: Request,
+    token: str = Depends(oauth2_scheme),
 ):
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        username = payload.get("sub")
-        if username is None:
-            raise HTTPException(status_code=401)
+    jti = get_jti_from_token(token)
+    history, expiry = sessions.get(jti, ([], 0.0))
 
-        return StreamingResponse(ollama_stream(request.query), media_type="application/json")
-    except JWTError:
-        raise HTTPException(status_code=401)
-    except httpx.RequestError as e:
-        raise HTTPException(status_code = 500, detail=f"Request failed: {e}")
+    if expiry < time.time():
+        history, expiry = [], 0.0
+
+    history.append({"role": "user", "content": payload.query})
+
+    assistant_chunks = bytearray()
+
+    async def streamer() -> AsyncGenerator[bytes, None]:
+        async for chunk in ollama_stream(history):
+            # Pass the chunk on to the client *and* keep a copy
+            yield chunk
+            assistant_chunks.extend(chunk)
+
+        # After the stream ends, append the assistant message to history
+        reply_text = assistant_chunks.decode("utf-8").strip()
+        history.append({"role": "assistant", "content": reply_text})
+
+        # Persist the new history with a TTL
+        sessions[jti] = (history, time.time() + ACCESS_TOKEN_EXPIRE_MINUTES * 60)
+
+    return StreamingResponse(streamer(), media_type="text/plain")

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.security import OAuth2PasswordBearer
 from pydantic import BaseModel
@@ -69,9 +71,11 @@ async def ollama_stream(history: list[dict]) -> AsyncGenerator[bytes, None]:
     """
     Async generator that yields raw bytes from Ollama as soon as they arrive.
     """
+    prompt = history_to_prompt(history)
+
     payload = {
         "model": MODEL_NAME,
-        "messages": history,
+        "prompt": prompt,
         "stream": True,
     }
 
@@ -109,18 +113,32 @@ async def ask(
     history.append({"role": "user", "content": payload.query})
 
     assistant_chunks = bytearray()
+    partial_reply: list[str] = []
 
     async def streamer() -> AsyncGenerator[bytes, None]:
         async for chunk in ollama_stream(history):
             # Pass the chunk on to the client *and* keep a copy
             yield chunk
+            data = json.loads(chunk.decode("utf-8"))
             assistant_chunks.extend(chunk)
+            if "response" in data and data["response"]:
+                partial_reply.append(data["response"])
 
         # After the stream ends, append the assistant message to history
-        reply_text = assistant_chunks.decode("utf-8").strip()
-        history.append({"role": "assistant", "content": reply_text})
+        final_text = "".join(partial_reply).strip()
+        history.append({"role": "assistant", "content": final_text})
 
         # Persist the new history with a TTL
         sessions[jti] = (history, time.time() + ACCESS_TOKEN_EXPIRE_MINUTES * 60)
 
     return StreamingResponse(streamer(), media_type="text/plain")
+
+def history_to_prompt(history: list[dict]) -> str:
+    """
+    Convert the list of message dicts into a single string that
+    Ollama’s /api/generate endpoint expects.
+    """
+    if not history:
+        return "You are a helpful chatbot. Start the conversation."
+    # Example:  role: content  \n
+    return "\n".join(f"{msg['role']}: {msg['content']}" for msg in history)

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from jose import JWTError, jwt
 from typing import Annotated
 from dotenv import load_dotenv
 import os
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, StreamingResponse
 
 # Load environment variables
 load_dotenv()
@@ -70,6 +70,18 @@ async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
     except JWTError:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
+def ollama_stream(prompt: str):
+    payload = {
+        "model": MODEL_NAME,
+        "prompt": prompt,
+        "stream": True
+    }
+
+    with httpx.stream("POST", OLLAMA_URL, json=payload) as response:
+        for chunk in response.iter_bytes():
+            if chunk:
+                yield chunk
+
 app = FastAPI()
 @app.get("/")
 def serve_frontend():
@@ -87,28 +99,15 @@ def login(request: LoginRequest) -> TokenResponse:
 async def ask(
         request: Request,
         token: str = Depends(oauth2_scheme)
-) -> Response:
+):
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         username = payload.get("sub")
         if username is None:
             raise HTTPException(status_code=401)
 
-        payload = {
-            "model": MODEL_NAME,
-            "prompt": request.query,
-            "stream": False
-        }
-
-        timeout = httpx.Timeout(30.0, connect = 5.0)
-        async with httpx.AsyncClient(timeout = timeout) as client:
-            response = await client.post(OLLAMA_URL, json = payload)
-            response.raise_for_status()
-            result = response.json()
-            return Response(response = result["response"])
+        return StreamingResponse(ollama_stream(request.query), media_type="application/json")
     except JWTError:
         raise HTTPException(status_code=401)
     except httpx.RequestError as e:
         raise HTTPException(status_code = 500, detail=f"Request failed: {e}")
-    except httpx.HTTPStatusError as e:
-        raise HTTPException(status_code = response.status_code, detail = str(e))

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Your Very Own Chatbot</title>
-    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-pU34JffS.js"></script>
+    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-B2hkUuWt.js"></script>
     <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Dtn62Xmo.css">
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Your Very Own Chatbot</title>
-    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-CIcLmfGB.js"></script>
-    <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Dtn62Xmo.css">
+    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Bca9WVlO.js"></script>
+    <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-LeGi8CjU.css">
   </head>
   <body>
     <div id="root"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Your Very Own Chatbot</title>
-    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Bca9WVlO.js"></script>
-    <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-LeGi8CjU.css">
+    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-DzwnROKx.js"></script>
+    <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-BH_gY8Bu.css">
   </head>
   <body  class="bg-gray-800">
     <div id="root"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Your Very Own Chatbot</title>
-    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-B2hkUuWt.js"></script>
+    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-CIcLmfGB.js"></script>
     <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Dtn62Xmo.css">
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Bca9WVlO.js"></script>
     <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-LeGi8CjU.css">
   </head>
-  <body>
+  <body  class="bg-gray-800">
     <div id="root"></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Your Very Own Chatbot</title>
-    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-qLLQB5o6.js"></script>
+    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-pU34JffS.js"></script>
     <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-Dtn62Xmo.css">
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Your Very Own Chatbot</title>
-    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-DzwnROKx.js"></script>
+    <script type="module" crossorigin src="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-CWKFBOwX.js"></script>
     <link rel="stylesheet" crossorigin href="https://cdn.phoenyx-studio.pp.ua/yvo-bot-frontend/assets/index-BH_gY8Bu.css">
   </head>
   <body  class="bg-gray-800">

--- a/session_store.py
+++ b/session_store.py
@@ -1,0 +1,7 @@
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+# type alias
+Session = Tuple[List[Dict[str, str]], float]   # (history, expiry_ts)
+
+sessions: Dict[str, Session] = defaultdict(lambda: ([], 0.0))


### PR DESCRIPTION
# dev → main: Streaming, Session History & JTI Auth

## Summary

- Replaced synchronous Ollama proxy with a fully async streaming implementation
- Added per-session conversation history tied to JWT identity (jti claim)
- Refactored single-file app into focused modules (`auth_utils`, `llm_stream`, `session_store`)
- Added frontend serving, pinned dependencies, and setup documentation

## Changes

### Async streaming (`llm_stream.py`, `main.py`)
The original synchronous `httpx.stream` generator is replaced with an `httpx.AsyncClient` async generator. Chunks are streamed to the client in real time without blocking the event loop.

### Per-session conversation history (`session_store.py`, `main.py`)
Each login now produces a JWT containing a unique `jti` (JWT ID) claim. The `jti` is used as the key in an in-memory session store that holds the full chat history for that session. History expires automatically when the token's TTL (`ACCESS_TOKEN_EXPIRE_MINUTES`) elapses — no separate cleanup job required.

### JTI-aware auth (`auth_utils.py`)
Token creation and `jti` extraction are extracted into `auth_utils.py`. `create_access_token` now embeds a `uuid4` jti and reads the expiry from `ACCESS_TOKEN_EXPIRE_MINUTES` (previously this config value was loaded but never applied).

### Frontend & setup
- `public/index.html` serves the compiled frontend from the CDN
- `.env-example` documents all required environment variables
- `requirements.txt` pins the full dependency tree
- README rewritten with quick-start instructions and API reference

## Test plan

- [ ] Start the server with a valid `.env` and confirm `GET /` returns the frontend
- [ ] `POST /login` with correct credentials returns a JWT; inspect it at jwt.io and confirm `jti` and `exp` are present
- [ ] `POST /login` with wrong credentials returns 401
- [ ] `POST /ask` with a valid token streams a response and subsequent messages in the same session reference prior context
- [ ] `POST /ask` with an expired or tampered token returns 401
- [ ] Restart the server and confirm session history is cleared (in-memory store does not persist across restarts)
